### PR TITLE
Link to create new issue from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Tact closed beta bugs
 
-Report any bugs about Tact closed beta to the “Issues” section of this repo.
+To report any bugs you find in the Tact closed beta, [create a new issue][new].
 
 ## Tact gotchas and quirks
 
 Here’s a list of gotchas about Tact behavior that may be useful to know.
 
 * **Message sending time and sorting.** Messages in chats are sorted by time. The time is set by the sender at the moment of message creation (clicking the “Send” button or tapping “Send” in iOS). It works fine across timezones. It is dependent on the sending device clock. If your clock is off, this will be reflected in message sort order.
+
+[new]: https://github.com/tact/beta-bugs/issues/new/choose


### PR DESCRIPTION
This updates the ReadMe file with a direct link to create a new issue, to make it easier for users who are less familiar with GitHub.